### PR TITLE
feat: add -cwd arg support for shadcn-svelte

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,13 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "files.exclude": {
-        "out": false, // set this to true to hide the "out" folder with the compiled JS files
-        "dist": false // set this to true to hide the "dist" folder with the compiled JS files
-    },
-    "search.exclude": {
-        "out": true, // set this to false to include "out" folder in search results
-        "dist": true // set this to false to include "dist" folder in search results
-    },
-    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+  "files.exclude": {
+    "out": false, // set this to true to hide the "out" folder with the compiled JS files
+    "dist": false // set this to true to hide the "dist" folder with the compiled JS files
+  },
+  "search.exclude": {
+    "out": true, // set this to false to include "out" folder in search results
+    "dist": true // set this to false to include "dist" folder in search results
+  },
+  // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+  "typescript.tsc.autoDetect": "off"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-shadcn-svelte",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "displayName": "shadcn/svelte",
   "description": "Integrate components and snippets from Shadcn/Svelte directly into your IDE.",
   "publisher": "Selemondev",
@@ -106,7 +106,17 @@
         "command": "shadcn-svelte.gotoDoc",
         "title": "shadcn/svelte: Open Documentation"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "shadcn/svelte",
+      "properties": {
+        "shadcn-svelte.cwd": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Absolute path to the working directory when running shadcn-svelte CLI. Default is the current workspace folder."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "yarn run package",
@@ -116,7 +126,7 @@
     "compile-tests": "tsc -p . --outDir out",
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "yarn run compile && yarn run lint",
-    "lint": "eslint src --ext ts"
+    "lint": "eslint src --ext ts --fix"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.6",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import {
   getRegistry,
   shadCnDocUrl,
 } from "./utils/registry";
-import { executeCommand } from "./utils/vscode";
+import { executeCommand, getOrChooseCwd } from "./utils/vscode";
 import type { Components } from "./utils/registry";
 
 const commands = {
@@ -24,7 +24,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   const disposables: vscode.Disposable[] = [
     vscode.commands.registerCommand(commands.initCli, async () => {
-      const intCmd = await getInitCmd();
+      const cwd = await getOrChooseCwd();
+      const intCmd = await getInitCmd(cwd);
       executeCommand(intCmd);
     }),
     vscode.commands.registerCommand(commands.addNewComponent, async () => {
@@ -40,14 +41,15 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       const selectedComponent = await vscode.window.showQuickPick(registryData, {
-        matchOnDescription: true,
-      });
+          matchOnDescription: true,
+        });
 
       if (!selectedComponent) {
         return;
       }
 
-      const installCmd = await getInstallCmd([selectedComponent.label]);
+      const cwd = await getOrChooseCwd();
+      const installCmd = await getInstallCmd([selectedComponent.label], cwd);
       executeCommand(installCmd);
     }),
 
@@ -64,9 +66,9 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       const selectedComponents = await vscode.window.showQuickPick(registryData, {
-        matchOnDescription: true,
-        canPickMany: true,
-      });
+          matchOnDescription: true,
+          canPickMany: true,
+        });
 
       if (!selectedComponents) {
         return;
@@ -74,7 +76,8 @@ export function activate(context: vscode.ExtensionContext) {
 
       const selectedComponent = selectedComponents.map((component) => component.label);
 
-      const installCmd = await getInstallCmd(selectedComponent);
+      const cwd = await getOrChooseCwd();
+      const installCmd = await getInstallCmd(selectedComponent, cwd);
       executeCommand(installCmd);
     }),
     vscode.commands.registerCommand(commands.gotoComponentDoc, async () => {

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -3,16 +3,16 @@ import { to } from "./index";
 import { detectPackageManager } from "./vscode";
 
 type OgComponent = {
-  type: "components:ui";
-  name: string;
-  files: string[];
-  dependencies?: string[];
-  registryDependencies?: string[];
+  type: "components:ui"
+  name: string
+  files: string[]
+  dependencies?: string[]
+  registryDependencies?: string[]
 };
 
 type Component = {
-  label: string;
-  detail?: string;
+  label: string
+  detail?: string
 };
 
 export const shadCnDocUrl = "https://shadcn-svelte.com/docs";
@@ -45,33 +45,33 @@ export const getRegistry = async (): Promise<Components | null> => {
   return components;
 };
 
-export const getInstallCmd = async (components: string[]) => {
+export const getInstallCmd = async (components: string[], cwd: string) => {
   const packageManager = await detectPackageManager();
   const componentStr = components.join(" ");
 
   if (packageManager === "bun") {
-    return `bunx shadcn-svelte add ${componentStr}`;
+    return `bunx shadcn-svelte add ${componentStr} -c ${cwd}`;
   }
 
   if (packageManager === "pnpm") {
-    return `pnpm dlx shadcn-svelte@latest add ${componentStr}`;
+    return `pnpm dlx shadcn-svelte@latest add ${componentStr} -c ${cwd}`;
   }
 
-  return `npx shadcn-svelte@latest add ${componentStr}`;
+  return `npx shadcn-svelte@latest add ${componentStr} -c ${cwd}`;
 };
 
-export const getInitCmd = async () => {
+export const getInitCmd = async (cwd: string) => {
   const packageManager = await detectPackageManager();
 
   if (packageManager === "bun") {
-    return "bunx shadcn-svelte init";
+    return `bunx shadcn-svelte init -c ${cwd}`;
   }
 
   if (packageManager === "pnpm") {
-    return "pnpm dlx shadcn-svelte@latest init";
+    return `pnpm dlx shadcn-svelte@latest init -c ${cwd}`;
   }
 
-  return "npx shadcn-svelte@latest init";
+  return `npx shadcn-svelte@latest init -c ${cwd}`;
 };
 
 export const getComponentDocLink = (component: string) => {

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -50,3 +50,40 @@ export const detectPackageManager = async (): Promise<PackageManager> => {
 
   return "npm";
 };
+
+export const getOrChooseCwd = async (): Promise<string> => {
+  const cwdFromConfig = vscode.workspace
+    .getConfiguration("shadcn-svelte")
+    .get<string>("cwd")
+    ?.trim();
+
+  // Always use the value from settings if it's provided
+  if (cwdFromConfig) {
+    return cwdFromConfig;
+  }
+
+  // Get the currently opened workspace folders
+  const workspaceFolders = (vscode.workspace.workspaceFolders ?? []).filter(
+    (f) => f.uri.scheme === "file"
+  );
+
+  // If there are no workspace folders open, just use the current working dir
+  if (!workspaceFolders.length) {
+    return "./";
+  }
+
+  // If there are multiple workspaces open, allow the user to pick which one
+  // they want to use.
+  const choice = await vscode.window.showQuickPick(
+    workspaceFolders.map((f) => f.name)
+  );
+
+  if (!choice) {
+    return "./";
+  }
+
+  // Map the chosen workspace name to absolute path
+  const fsPath = workspaceFolders.find((f) => f.name === choice)?.uri.fsPath;
+
+  return fsPath ?? "./";
+};


### PR DESCRIPTION
This change enables support for multiple workspaces as well as a custom base directory when adding new components.

I use a monorepo layout which means the shadcn-svelte components.json file is not in the top-level directory. With this change, you can now set shadcn-svelte.cwd to whichever sub directory your components.json file sits in. 

E.g. You would set it to "./apps/web" for the following directory structure:

```
- apps/
  - web/
    - components.json
  - api/
    - ... 
```