### PR TITLE
fix: ofetch module missing after installation

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
     clean: true,
     platform: 'node',
     sourcemap: false,
-    external: ['vscode']
+    external: ['vscode'],
+    noExternal: ['ofetch'],
 })


### PR DESCRIPTION
By default, `tsup` automatically excludes packages specified in the **dependencies** and **peer dependencies** fields in the package.json file.

When install from vscode marketplace, it will gives an error as below:
```logs
Activating extension 'Selemondev.vscode-shadcn-svelte' failed: Cannot find module 'ofetch'
```

From the above error, it seems like the package `ofetch` is missing. The commit fix the issue.