### PR TITLE
fix: import typo in drawer snippet

### DIFF
--- a/src/snippets/imports-code-snippets.json
+++ b/src/snippets/imports-code-snippets.json
@@ -178,7 +178,7 @@
       "cni-drawer"
     ],
     "body": [
-      "  import * as Drawer from \"$lib/components/ui/drawer\"",
+      "  import * as Drawer from \"$$lib/components/ui/drawer\"",
       ""
     ],
     "description": "https://shadcn-svelte.com/docs/components/drawer.html"


### PR DESCRIPTION
there is an $ missing in the drawer import