### PR TITLE
ci: add GitHub workflow for extension publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish Extension
+
+on:
+  push:
+    tags:
+      - "v*.*.*" # Trigger on new version tags
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js with pnpm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Lint code
+        run: pnpm run lint
+
+      - name: Check types
+        run: pnpm run check-types
+
+      - name: Build the extension
+        run: pnpm run build
+
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        id: publishToOpenVSX
+        with:
+          pat: ${{ secrets.OVSX_PAT }}
+
+      - name: Publish to VS Code Marketplace
+        if: secrets.VSCE_PAT != ''
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VSCE_PAT }}
+          registryUrl: https://marketplace.visualstudio.com
+          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vscode-shadcn-svelte",
   "version": "0.1.14",
+  "license": "MIT",
   "displayName": "shadcn/svelte",
   "description": "Integrate components and snippets from Shadcn/Svelte directly into your IDE ✨.",
   "publisher": "Selemondev",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "build": "pnpm run lint && node esbuild.js --production",
     "dev": "pnpm build -- --watch",
     "deploy:extension": "vsce publish --no-dependencies",
+    "deploy:openvsx": "ovsx publish -p $OVSX_PAT",
     "lint": "eslint src --ext ts"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow to automate the publishing process for the `vscode-shadcn-svelte` extension to Visual Studio Marketplace and the Open VSX Registry. It will run automatically on every new version that matches the pattern `v*.*.*` (e.g., v1.0.0 or v2.3.4).

closes #8 

### Next Steps

There are two more steps necessary that I can't do as I'm not an owner of the repo:

1. **Set up Open VSX account**:
   - Create an [Eclipse account](https://accounts.eclipse.org/).
   - Sign the **Publisher Agreement** on [Open VSX](https://open-vsx.org/).
1. **Create the namespace**:
     ```bash
     npx ovsx create-namespace Selemondev -p <OPEN_VSX_TOKEN>
     ```
     *(Replace `<OPEN_VSX_TOKEN>` with your Open VSX access token.)*
1. **Add repository secrets**:
   - Go to **Settings > Secrets and Variables > Actions** in your GitHub repository.
   - Add the following secrets:
     - `OVSX_PAT` – Open VSX personal access token.
     - `VSCE_PAT` – Visual Studio Marketplace token (optional, if you want to automate the Marketplace publishing too).
