### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/selemondev/vscode-shadcn-svelte/security/code-scanning/1](https://github.com/selemondev/vscode-shadcn-svelte/security/code-scanning/1)

To fix the problem, the workflow should include a `permissions` block specifying the minimum necessary level for the GITHUB_TOKEN for this job. The safest minimum starting point is `contents: read`, because most actions (like `checkout` for source code) only require read access to the repository contents. Since publishing to both Open VSX and the VS Code Marketplace is done via explicit secrets and not the GITHUB_TOKEN, `contents: read` suffices. The best fix is to add `permissions: contents: read` at the job level, directly under the `publish` job, or at the workflow root if all jobs should inherit it. In this case, a single job is shown, so setting it at the job level immediately after `publish:` and before `runs-on:` is preferred.

**Edit**:  
In `.github/workflows/publish.yml`,  
Insert the following block under `publish:` (i.e., after line 10):  
```yaml
    permissions:
      contents: read
```
No other code changes are necessary.

---
