### PR TITLE
feat: add `update components` command to update installed components

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "onCommand:shadcn-svelte.initCli",
     "onCommand:shadcn-svelte.addNewComponent",
     "onCommand:shadcn-svelte.addMultipleComponents",
+    "onCommand:shadcn-svelte.updateComponents",
     "onCommand:shadcn-svelte.gotoComponentDoc",
     "onCommand:shadcn-svelte.reloadComponentList",
     "onCommand:shadcn-svelte.gotoDoc"
@@ -137,6 +138,10 @@
       {
         "command": "shadcn-svelte.addMultipleComponents",
         "title": "shadcn/svelte: Add Multiple Components"
+      },
+      {
+        "command": "shadcn-svelte.updateComponents",
+        "title": "shadcn/svelte: Update Components"
       },
       {
         "command": "shadcn-svelte.gotoComponentDoc",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,16 +3,22 @@ import { ShadcnSnippetCompletionProvider } from "./completion-provider";
 import {
   getInitCmd,
   getInstallCmd,
+  getUpdateCmd,
   getComponentDocLink,
 } from "./utils/registry";
 import { executeCommand, getOrChooseCwd } from "./utils/vscode";
 import { getSvelteVersion } from "./utils/getSvelteVersion";
+import { getInstalledComponents } from "./utils/installedComponents";
+import { getDirtyStatus, HeadContentProvider, HEAD_CONTENT_SCHEME } from "./utils/git";
+import { runCommand } from "./utils/exec";
+import { openComponentDiffs } from "./utils/diff";
 import type { Component, Components } from "./utils/registry";
 
 const commands = {
   initCli: "shadcn-svelte.initCli",
   addNewComponent: "shadcn-svelte.addNewComponent",
   addMultipleComponents: "shadcn-svelte.addMultipleComponents",
+  updateComponents: "shadcn-svelte.updateComponents",
   gotoComponentDoc: "shadcn-svelte.gotoComponentDoc",
   reloadComponentList: "shadcn-svelte.reloadComponentList",
   gotoDoc: "shadcn-svelte.gotoDoc",
@@ -21,6 +27,8 @@ const commands = {
 export async function activate(context: vscode.ExtensionContext) {
   const snippetCompletionProvider = new ShadcnSnippetCompletionProvider(context);
   await snippetCompletionProvider.initialize();
+
+  const outputChannel = vscode.window.createOutputChannel("shadcn/svelte");
 
   let registryData: Components = snippetCompletionProvider.getRegistryComponents();
   const requireWorkspace = () => {
@@ -33,7 +41,12 @@ export async function activate(context: vscode.ExtensionContext) {
   };
 
   const disposables: vscode.Disposable[] = [
+    outputChannel,
     snippetCompletionProvider.register(),
+    vscode.workspace.registerTextDocumentContentProvider(
+      HEAD_CONTENT_SCHEME,
+      new HeadContentProvider(),
+    ),
     vscode.commands.registerCommand(commands.initCli, async () => {
       if (!requireWorkspace()) {
         return;
@@ -96,6 +109,111 @@ export async function activate(context: vscode.ExtensionContext) {
       const cwd = await getOrChooseCwd();
       const installCmd = await getInstallCmd(selectedComponent, cwd);
       executeCommand(installCmd);
+    }),
+
+    vscode.commands.registerCommand(commands.updateComponents, async () => {
+      if (!requireWorkspace()) {
+        return;
+      }
+
+      const newRegistryData = await snippetCompletionProvider.refresh();
+
+      if (!newRegistryData.registryComponents.length) {
+        vscode.window.showErrorMessage("Cannot get the component list");
+        return;
+      }
+
+      registryData = newRegistryData.registryComponents;
+
+      const cwd = await getOrChooseCwd();
+      const installed = await getInstalledComponents(vscode.Uri.file(cwd), registryData);
+
+      if (!installed.components.length) {
+        vscode.window.showInformationMessage(
+          "shadcn/svelte: No installed components found to update.",
+        );
+        return;
+      }
+
+      const selectedComponents = await vscode.window.showQuickPick(installed.components, {
+        matchOnDescription: true,
+        canPickMany: true,
+        placeHolder: "Select installed components to update (re-installs the latest version)",
+      });
+
+      if (!selectedComponents || !selectedComponents.length) {
+        return;
+      }
+
+      const componentNames = selectedComponents.map((component: Component) => component.label);
+
+      // Guard against silently overwriting user customizations. A clean baseline is also
+      // what makes the post-update diff and per-file revert reliable.
+      const { isRepo, dirty } = await getDirtyStatus(cwd, installed.uiDir.fsPath);
+
+      let warning: string | undefined;
+      if (!isRepo) {
+        warning =
+          "This folder isn't a git repository, so changes can't be reviewed or reverted. Updating will overwrite the selected components in place.";
+      } else if (dirty) {
+        warning =
+          "Your components directory has uncommitted changes. Updating will overwrite the selected components and you may lose those edits.";
+      }
+
+      if (warning) {
+        const proceed = await vscode.window.showWarningMessage(
+          warning,
+          { modal: true },
+          "Update anyway",
+        );
+        if (proceed !== "Update anyway") {
+          return;
+        }
+      } else {
+        const proceed = await vscode.window.showWarningMessage(
+          `Overwrite ${componentNames.length} component(s) with the latest version?\n\n${componentNames.join(", ")}`,
+          { modal: true },
+          "Update",
+        );
+        if (proceed !== "Update") {
+          return;
+        }
+      }
+
+      const updateCmd = await getUpdateCmd(componentNames, cwd);
+
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: `shadcn/svelte: Updating ${componentNames.length} component(s)…`,
+          cancellable: false,
+        },
+        async () => {
+          // Run silently: stream to the (hidden) output channel without revealing it.
+          // The progress notification, diff tabs, and toast are the only visible UI.
+          const result = await runCommand(updateCmd, cwd, outputChannel);
+
+          if (result.code !== 0) {
+            vscode.window.showErrorMessage(
+              `shadcn/svelte: Update failed (exit code ${result.code}). See the "shadcn/svelte" output for details.`,
+            );
+            return;
+          }
+
+          if (isRepo) {
+            const diffCount = await openComponentDiffs(cwd, installed.uiDir.fsPath);
+            vscode.window.showInformationMessage(
+              diffCount > 0
+                ? `shadcn/svelte: Updated ${componentNames.length} component(s). Review ${diffCount} changed file(s) in the opened diffs.`
+                : `shadcn/svelte: ${componentNames.length} component(s) were already up to date.`,
+            );
+          } else {
+            vscode.window.showInformationMessage(
+              `shadcn/svelte: Updated ${componentNames.length} component(s).`,
+            );
+          }
+        },
+      );
     }),
     vscode.commands.registerCommand(commands.gotoComponentDoc, async () => {
       const newRegistryData = await snippetCompletionProvider.refresh();

--- a/src/test/vscode.ts
+++ b/src/test/vscode.ts
@@ -66,10 +66,21 @@ export class Uri {
     return new Uri([base.fsPath, ...paths].join("/").replace(/\/+/g, "/"));
   }
 
+  static from(components: { scheme: string; path?: string; query?: string }) {
+    return new Uri(components.path ?? "");
+  }
+
   toString() {
     return this.fsPath;
   }
 }
+
+export const FileType = {
+  Unknown: 0,
+  File: 1,
+  Directory: 2,
+  SymbolicLink: 64,
+} as const;
 
 export class FileSystemError extends Error {
   constructor(message: string, public readonly code: string) {
@@ -90,6 +101,7 @@ export const workspace = {
   fs: {
     readFile: vi.fn(),
     stat: vi.fn(),
+    readDirectory: vi.fn(),
   },
 };
 

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,0 +1,32 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { buildHeadUri, getChangedFiles } from "./git";
+
+/**
+ * After an update runs, open a diff tab (HEAD -> working tree) for every changed file under
+ * the UI directory so the user is walked through each change and can revert via git if needed.
+ *
+ * @returns the number of changed files for which a diff was opened.
+ */
+export const openComponentDiffs = async (cwd: string, uiDir: string): Promise<number> => {
+  const changedFiles = await getChangedFiles(cwd, uiDir);
+
+  for (const file of changedFiles) {
+    const fileUri = vscode.Uri.file(file.absPath);
+    const fileName = path.basename(file.absPath);
+
+    // Newly added files have no HEAD version; an empty left side reads as "all new".
+    const headUri = buildHeadUri(cwd, file);
+    const title = file.added ? `${fileName} (new)` : `${fileName} (updated ↔ HEAD)`;
+
+    await vscode.commands.executeCommand(
+      "vscode.diff",
+      headUri,
+      fileUri,
+      title,
+      { preview: false },
+    );
+  }
+
+  return changedFiles.length;
+};

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,0 +1,48 @@
+import { spawn } from "node:child_process";
+import * as vscode from "vscode";
+
+export type CommandResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+/**
+ * Run a shell command programmatically, streaming output to an OutputChannel, and resolve
+ * once it exits. Unlike the terminal pipeline (which is fire-and-forget), this gives us a
+ * completion signal and an exit code so callers can react to success/failure.
+ */
+export const runCommand = (
+  command: string,
+  cwd: string,
+  outputChannel: vscode.OutputChannel,
+): Promise<CommandResult> => {
+  return new Promise((resolve, reject) => {
+    outputChannel.appendLine(`$ ${command}`);
+
+    const child = spawn(command, { cwd, shell: true });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stdout += text;
+      outputChannel.append(text);
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stderr += text;
+      outputChannel.append(text);
+    });
+
+    child.on("error", (error) => {
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+};

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,0 +1,111 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import * as path from "node:path";
+import * as vscode from "vscode";
+
+const execAsync = promisify(exec);
+
+export const HEAD_CONTENT_SCHEME = "shadcn-svelte-head";
+
+const runGit = async (args: string, cwd: string): Promise<string | null> => {
+  try {
+    const { stdout } = await execAsync(`git ${args}`, { cwd, maxBuffer: 1024 * 1024 * 32 });
+    return stdout;
+  } catch {
+    return null;
+  }
+};
+
+export const getRepoRoot = async (cwd: string): Promise<string | null> => {
+  const out = await runGit("rev-parse --show-toplevel", cwd);
+  return out ? out.trim() : null;
+};
+
+export type DirtyStatus = {
+  isRepo: boolean;
+  dirty: boolean;
+};
+
+/** Report whether `targetDir` has uncommitted changes (and whether we're in a git repo at all). */
+export const getDirtyStatus = async (cwd: string, targetDir: string): Promise<DirtyStatus> => {
+  const repoRoot = await getRepoRoot(cwd);
+  if (!repoRoot) {
+    return { isRepo: false, dirty: false };
+  }
+
+  const status = await runGit(`status --porcelain -- "${targetDir}"`, cwd);
+  return { isRepo: true, dirty: Boolean(status && status.trim().length > 0) };
+};
+
+export type ChangedFile = {
+  /** Absolute path to the file on disk. */
+  absPath: string;
+  /** Path relative to the repository root (used for `git show HEAD:<path>`). */
+  repoRelPath: string;
+  /** True when the file is newly added (no HEAD version to diff against). */
+  added: boolean;
+};
+
+/** List files under `targetDir` that changed in the working tree relative to HEAD. */
+export const getChangedFiles = async (cwd: string, targetDir: string): Promise<ChangedFile[]> => {
+  const repoRoot = await getRepoRoot(cwd);
+  if (!repoRoot) {
+    return [];
+  }
+
+  const status = await runGit(`status --porcelain -- "${targetDir}"`, cwd);
+  if (!status) {
+    return [];
+  }
+
+  const files: ChangedFile[] = [];
+  for (const line of status.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    // Porcelain format: "XY <path>" where XY are status codes.
+    const code = line.slice(0, 2);
+    const filePart = line.slice(3).trim();
+    // Renames are reported as "old -> new"; keep the new path.
+    const repoRelPath = filePart.includes(" -> ") ? filePart.split(" -> ")[1] : filePart;
+    const added = code.includes("?") || code.includes("A");
+
+    files.push({
+      absPath: path.join(repoRoot, repoRelPath),
+      repoRelPath,
+      added,
+    });
+  }
+
+  return files;
+};
+
+/**
+ * Provides the HEAD version of a file (via `git show HEAD:<path>`) for use as the left-hand
+ * side of a diff. The repo cwd and repo-relative path are encoded in the URI query.
+ */
+export class HeadContentProvider implements vscode.TextDocumentContentProvider {
+  async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+    const params = new URLSearchParams(uri.query);
+    const cwd = params.get("cwd");
+    const repoRelPath = params.get("path");
+
+    if (!cwd || !repoRelPath) {
+      return "";
+    }
+
+    const content = await runGit(`show "HEAD:${repoRelPath}"`, cwd);
+    return content ?? "";
+  }
+}
+
+/** Build a `shadcn-svelte-head:` URI that the provider resolves to the file's HEAD content. */
+export const buildHeadUri = (cwd: string, file: ChangedFile): vscode.Uri => {
+  const query = new URLSearchParams({ cwd, path: file.repoRelPath }).toString();
+  return vscode.Uri.from({
+    scheme: HEAD_CONTENT_SCHEME,
+    path: file.repoRelPath,
+    query,
+  });
+};

--- a/src/utils/installedComponents.test.ts
+++ b/src/utils/installedComponents.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FileType, Uri, workspace } from "../test/vscode";
+import { aliasToRelativeDir, getInstalledComponents } from "./installedComponents";
+import type { Components } from "./registry";
+
+describe("aliasToRelativeDir", () => {
+  it("maps the default $lib alias to src/lib", () => {
+    expect(aliasToRelativeDir("$lib/components/ui")).toBe("src/lib/components/ui");
+    expect(aliasToRelativeDir("$lib")).toBe("src/lib");
+  });
+
+  it("strips other path-alias markers and trailing slashes", () => {
+    expect(aliasToRelativeDir("@/components/ui/")).toBe("components/ui");
+    expect(aliasToRelativeDir("./src/lib/components/ui")).toBe("src/lib/components/ui");
+  });
+});
+
+describe("getInstalledComponents", () => {
+  const registry: Components = [
+    { label: "button", detail: "dependencies: no dependency" },
+    { label: "card", detail: "dependencies: no dependency" },
+    { label: "alert-dialog", detail: "dependencies: button" },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("intersects directories on disk with the registry and flags unknowns", async () => {
+    vi.mocked(workspace.fs.readFile).mockResolvedValue(
+      Buffer.from(JSON.stringify({ aliases: { ui: "$lib/components/ui" } })),
+    );
+    vi.mocked(workspace.fs.readDirectory).mockResolvedValue([
+      ["button", FileType.Directory],
+      ["card", FileType.Directory],
+      ["my-custom-thing", FileType.Directory],
+      ["index.ts", FileType.File],
+    ]);
+
+    const result = await getInstalledComponents(Uri.file("/workspace") as unknown as import("vscode").Uri, registry);
+
+    expect(result.uiDir.fsPath).toBe("/workspace/src/lib/components/ui");
+    expect(result.components.map((c) => c.label)).toEqual(["button", "card"]);
+    expect(result.unknown).toEqual(["my-custom-thing"]);
+  });
+
+  it("falls back to the default UI dir when components.json is missing", async () => {
+    vi.mocked(workspace.fs.readFile).mockRejectedValue(new Error("not found"));
+    vi.mocked(workspace.fs.readDirectory).mockResolvedValue([
+      ["button", FileType.Directory],
+    ]);
+
+    const result = await getInstalledComponents(Uri.file("/workspace") as unknown as import("vscode").Uri, registry);
+
+    expect(result.uiDir.fsPath).toBe("/workspace/src/lib/components/ui");
+    expect(result.components.map((c) => c.label)).toEqual(["button"]);
+  });
+
+  it("returns empty results when the UI directory has no component folders", async () => {
+    vi.mocked(workspace.fs.readFile).mockResolvedValue(
+      Buffer.from(JSON.stringify({ aliases: { ui: "$lib/components/ui" } })),
+    );
+    vi.mocked(workspace.fs.readDirectory).mockResolvedValue([]);
+
+    const result = await getInstalledComponents(Uri.file("/workspace") as unknown as import("vscode").Uri, registry);
+
+    expect(result.components).toEqual([]);
+    expect(result.unknown).toEqual([]);
+  });
+});

--- a/src/utils/installedComponents.ts
+++ b/src/utils/installedComponents.ts
@@ -1,0 +1,95 @@
+import * as vscode from "vscode";
+import { resolveUiAliasBase } from "../completion-provider/document-config";
+import { DEFAULT_LIB_ALIAS, DEFAULT_UI_ALIAS } from "../completion-provider/constants";
+import type { ComponentsConfig } from "../completion-provider/types";
+import type { Component, Components } from "./registry";
+
+/**
+ * Convert a resolved UI alias (e.g. `$lib/components/ui`) into a workspace-relative
+ * filesystem directory (e.g. `src/lib/components/ui`).
+ *
+ * SvelteKit maps `$lib` to `src/lib` by default; we assume that default. Aliases that
+ * don't use the `$lib` convention are returned with any leading `$`/`@` marker stripped
+ * so they resolve against the workspace root.
+ */
+export const aliasToRelativeDir = (aliasBase: string): string => {
+  const normalized = aliasBase.trim().replace(/^\.?\/+/, "").replace(/\/+$/, "");
+
+  if (normalized === DEFAULT_LIB_ALIAS || normalized.startsWith(`${DEFAULT_LIB_ALIAS}/`)) {
+    return normalized.replace(DEFAULT_LIB_ALIAS, "src/lib");
+  }
+
+  // Strip a leading path-alias marker (e.g. `@/components/ui` -> `components/ui`).
+  return normalized.replace(/^[$@][^/]*\//, "");
+};
+
+const readComponentsConfig = async (
+  baseUri: vscode.Uri,
+): Promise<ComponentsConfig | null> => {
+  try {
+    const configPath = vscode.Uri.joinPath(baseUri, "components.json");
+    const configContent = await vscode.workspace.fs.readFile(configPath);
+    const rawConfig = Buffer.from(configContent).toString("utf8");
+    return JSON.parse(rawConfig) as ComponentsConfig;
+  } catch {
+    return null;
+  }
+};
+
+const listSubdirectories = async (dir: vscode.Uri): Promise<string[]> => {
+  try {
+    const entries = await vscode.workspace.fs.readDirectory(dir);
+    return entries
+      .filter(([, fileType]) => fileType === vscode.FileType.Directory)
+      .map(([name]) => name);
+  } catch {
+    return [];
+  }
+};
+
+export type InstalledComponentsResult = {
+  uiDir: vscode.Uri;
+  /** QuickPick items for components that are both installed and present in the registry. */
+  components: Components;
+  /** Directory names found on disk that are not present in the registry. */
+  unknown: string[];
+};
+
+/**
+ * Discover installed UI components by reading `components.json`, resolving the UI alias to
+ * a directory, and intersecting the directories on disk with the known registry.
+ */
+export const getInstalledComponents = async (
+  baseUri: vscode.Uri,
+  registry: Components,
+): Promise<InstalledComponentsResult> => {
+  const config = await readComponentsConfig(baseUri);
+  const aliasBase = config ? resolveUiAliasBase(config) : DEFAULT_UI_ALIAS;
+  const relativeDir = aliasToRelativeDir(aliasBase);
+  const uiDir = vscode.Uri.joinPath(baseUri, relativeDir);
+
+  const installedNames = await listSubdirectories(uiDir);
+  if (!installedNames.length) {
+    return { uiDir, components: [], unknown: [] };
+  }
+
+  const registryByName = new Map<string, Component>(
+    registry.map((component) => [component.label, component]),
+  );
+
+  const components: Components = [];
+  const unknown: string[] = [];
+
+  for (const name of installedNames) {
+    const match = registryByName.get(name);
+    if (match) {
+      components.push(match);
+    } else {
+      unknown.push(name);
+    }
+  }
+
+  components.sort((a, b) => a.label.localeCompare(b.label));
+
+  return { uiDir, components, unknown };
+};

--- a/src/utils/registry.test.ts
+++ b/src/utils/registry.test.ts
@@ -9,7 +9,7 @@ vi.mock("./vscode", () => ({
   detectPackageManager: vi.fn(),
 }));
 
-import { getComponentDocLink, getInitCmd, getInstallCmd, getRegistry } from "./registry";
+import { getComponentDocLink, getInitCmd, getInstallCmd, getRegistry, getUpdateCmd } from "./registry";
 import { detectPackageManager } from "./vscode";
 
 describe("registry helpers", () => {
@@ -79,6 +79,23 @@ describe("registry helpers", () => {
     );
     await expect(getInstallCmd(["button"], "/workspace")).resolves.toBe(
       "npx shadcn-svelte@latest add button -c /workspace",
+    );
+  });
+
+  it("builds update commands with the overwrite flag for the supported package managers", async () => {
+    vi.mocked(detectPackageManager)
+      .mockResolvedValueOnce("bun")
+      .mockResolvedValueOnce("pnpm")
+      .mockResolvedValueOnce("npm");
+
+    await expect(getUpdateCmd(["button", "badge"], "/workspace")).resolves.toBe(
+      "bunx shadcn-svelte@latest add button badge --overwrite -y -c /workspace",
+    );
+    await expect(getUpdateCmd(["button"], "/workspace")).resolves.toBe(
+      "pnpm dlx shadcn-svelte@latest add button --overwrite -y -c /workspace",
+    );
+    await expect(getUpdateCmd(["button"], "/workspace")).resolves.toBe(
+      "npx shadcn-svelte@latest add button --overwrite -y -c /workspace",
     );
   });
 

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -75,6 +75,23 @@ export const getInstallCmd = async (components: string[], cwd: string) => {
   return `npx shadcn-svelte@latest add ${componentStr} -c ${cwd}`;
 };
 
+export const getUpdateCmd = async (components: string[], cwd: string) => {
+  const packageManager = await detectPackageManager();
+  const componentStr = components.join(" ");
+
+  // `-y` skips the CLI's "Ready to install?" confirmation; without it the spawned
+  // (non-TTY) process would hang waiting for input. `--overwrite` replaces the files.
+  if (packageManager === "bun") {
+    return `bunx shadcn-svelte@latest add ${componentStr} --overwrite -y -c ${cwd}`;
+  }
+
+  if (packageManager === "pnpm") {
+    return `pnpm dlx shadcn-svelte@latest add ${componentStr} --overwrite -y -c ${cwd}`;
+  }
+
+  return `npx shadcn-svelte@latest add ${componentStr} --overwrite -y -c ${cwd}`;
+};
+
 export const getInitCmd = async (cwd: string) => {
   const packageManager = await detectPackageManager();
 


### PR DESCRIPTION
`TLDR`: The shadcn-svelte registry has no per-component versions, so this isn't a "3 updates available" checker instead it re-pulls the latest changes and shows you the diff.

This pull request adds a new shadcn/svelte `update components` command. It reads your components.json, finds the components you actually have in your `ui/` directory, and lets you pick which components you want to update. It then re-runs `add --overwrite` for those components in the background and opens a diff for every file that changed, so you can see exactly what's different and either keep, discard, or partially apply the changes.

If your components folder has uncommitted changes, it warns you first to avoid overwriting your changes. The whole review/undo flow leans on git, so it needs a clean baseline before overwriting anything.

Closes #149 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command to update installed components from the registry.
  * Users can now review updates in a diff view before applying them, including support for newly added and modified files.
  * The extension now shows clearer progress, success, and error messages during update runs.

* **Bug Fixes**
  * Improved detection of installed components and workspace directories.
  * Better handling of Git status, including warning prompts when there are uncommitted changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->